### PR TITLE
docs: update README with system prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # BOS
 BOS (Bugema Operating System) the internet OS! Free, Open Source, Self hostable
+
+## Prerequisites
+Before running this project, ensure you have the following installed:
+- Node.js (v18.0 or higher)
+- Git
+- A modern web browser (Chrome, Firefox, or Edge)


### PR DESCRIPTION
Listed the minimum software versions required to run the BOS project (Node.js v18+ and Git). This prevents version mismatch errors during the installation process.

Closes #1