### PR TITLE
Add OSS evaluation report

### DIFF
--- a/oss_evaluation_report.md
+++ b/oss_evaluation_report.md
@@ -1,0 +1,71 @@
+# Open Source Evaluation — BOS
+
+**Repository:** `bos-com/BOS`
+**Snapshot date:** 29 April 2026
+**Author:** Coursework submission
+
+This file is one of four sibling reports — each in its own repository — that together evaluate the four flagship Bugema Open Source Community (BOSC) projects against open source principles. The companion files live in `bos-com/GreenCode`, `bos-com/OpenCare-Core`, and `bos-com/LifeLine-ICT`. Every claim below is grounded in publicly verifiable evidence from this repository, the BOSC organisation profile, and the `bos-com/bosc-governance` repository, captured on the snapshot date above.
+
+## 1. Evaluation framework
+
+Six principles are applied (drawn from the OSI Open Source Definition, GitHub's Open Source Guides, and CHAOSS community-health metrics):
+
+1. **Recognised licence at root.**
+2. **README covers purpose, scope, and setup.**
+3. **Explicit project-level governance** (CONTRIBUTING, CODE_OF_CONDUCT, GOVERNANCE).
+4. **Inclusive contribution workflow** (issue/PR templates, labels, "good first issue").
+5. **Active maintenance and review velocity.**
+6. **Code of conduct + security policy at repo level.**
+
+Each principle is graded **Met / Partial / Not met / Unknown**.
+
+## 2. Project profile
+
+BOS is the namesake project of the Bugema Open Source community — the GitHub API description is "BOS (Bugema Operating System) the internet OS! Free, Open Source, Self hostable." In practice, **the repository is a placeholder.** Listing the root via the GitHub Contents API returns only two files: `LICENSE` and `README.md`. The README itself is a single line — the same description quoted above — with no further content, no architecture document, no roadmap, and no scope statement. The total repository size is **1 KB**.
+
+The project was created on 26 August 2025 and was last pushed on **26 August 2025** — there has been no push since the initial commit. The primary language field is empty because there is no source code. GitHub-side metrics: **37 forks, 0 stars, 73 open issues, 0 PRs visible.** That pattern — high forks and high issues against an empty codebase — is the classic signature of a repository being used as a **pedagogical scaffold**: students fork and file issues as part of a coursework exercise, but no actual product development is happening.
+
+## 3. Licensing
+
+Despite being effectively empty, BOS does ship an `MIT License` at the root. So in the narrow sense of "if there were code here, it would be openly licensed," BOS satisfies the licence principle. **Principle 1: Met.**
+
+## 4. Governance and community files
+
+There is no `CONTRIBUTING.md`, no `CODE_OF_CONDUCT.md`, no `SECURITY.md`, and no `GOVERNANCE.md` in BOS. As with every other BOSC flagship project, the BOSC-wide governance documents in `bos-com/bosc-governance` are not linked from this repository. **Principle 3: Not met. Principle 6: Not met.**
+
+## 5. Contribution workflow
+
+The contribution metrics are paradoxical and informative. BOS has 37 forks and 73 open issues — comparable to the active flagship projects — but no codebase against which to measure contributions, and no closed PRs. The activity is real in volume but it cannot represent product development, because there is no product. The most plausible explanation is that BOS is being used as a **shared exercise space**: students fork the empty repository and use the issue tracker for coursework activities like writing user stories, drafting requirements, or proposing architectures.
+
+For an outside observer, however, that pedagogical use is invisible. What a visitor sees is a flagship-named project of the BOSC community with a one-line README and no code. From an open-source-principles perspective, there is essentially nothing to evaluate beyond the licence, because there is no project in the working sense.
+
+**Principle 2: Not met** — the README does not describe purpose, scope, or setup. **Principle 4: Not met** — there is no codebase against which a contribution workflow can operate. **Principle 5: Not met** — no push since the day the repository was created.
+
+## 6. Verdict and recommendations
+
+| Principle | Verdict |
+|---|---|
+| 1. Recognised licence at root | **Met** (MIT) |
+| 2. README covers purpose, scope, setup | **Not met** |
+| 3. Explicit project-level governance | **Not met** |
+| 4. Inclusive contribution workflow | **Not met** |
+| 5. Active maintenance and review velocity | **Not met** |
+| 6. Code of conduct + security policy | **Not met** |
+
+**Three concrete next actions, in priority order:**
+
+1. **Decide BOS's scope or archive it.** The repository is currently a credibility risk: it carries the BOSC brand on a project that does not exist. Either commit a real architecture document, scope statement, and initial scaffolding — even minimal scaffolding is a meaningful upgrade over the current state — or mark the repository explicitly archived in GitHub's UI so prospective contributors know the project is dormant.
+2. **If BOS is being used as a teaching scaffold, say so in the README.** A short paragraph along the lines of "This repository is currently used by Bugema University coursework as a planning exercise; an initial implementation is targeted for 〈date〉" reframes the empty state from "abandoned" to "intentional," which is much less harmful to BOSC's reputation.
+3. **Close or migrate the 73 open issues.** If the issues belong to coursework exercises rather than the product, they should either be closed when the exercise ends or migrated to a `bos-com/student-projects`-style repository so the namesake repository does not carry coursework backlog indefinitely.
+
+BOS is best described as a **stub**. Of the four BOSC flagship projects, it is the only one for which the most useful recommendation is not "improve" but "decide." The community has done real work on the other three flagship projects; BOS would benefit either from comparable real work or from honest archival.
+
+## 7. Sources
+
+- GitHub REST API: `/repos/bos-com/BOS`, `/repos/bos-com/BOS/contents/`.
+- GitHub web pages: `README.md`, `LICENSE`.
+- BOSC governance: `https://github.com/bos-com/bosc-governance`.
+- BOSC organisation profile: `https://github.com/bos-com`.
+- Framework: OSI *Open Source Definition*; GitHub *Open Source Guides*; CHAOSS community-health metrics.
+
+Counts and timestamps are accurate as of 29 April 2026 and will drift as the project develops.


### PR DESCRIPTION
One of four sibling reports across the BOSC flagship repositories evaluating each against six open-source principles. Snapshot taken 2026-04-29; only publicly verifiable evidence used.